### PR TITLE
autobuild: clean srcdir to remove cached Meson subprojects

### DIFF
--- a/autobuild/run.py
+++ b/autobuild/run.py
@@ -81,6 +81,8 @@ def setup():
         subprocess.run(
             ['git', 'reset', '--hard', 'FETCH_HEAD'], cwd=SRCDIR, check=True
         )
+        # remove cached Meson subprojects
+        subprocess.run(['git', 'clean', '-dxf'], cwd=SRCDIR, check=True)
     else:
         subprocess.run(['git', 'clone', REPO, SRCDIR], check=True)
 


### PR DESCRIPTION
Avoid reusing stale versions of subprojects on subsequent builds.