### PR TITLE
autobuild: enthusiastically clean srcdir to remove Meson subprojects

### DIFF
--- a/autobuild/run.py
+++ b/autobuild/run.py
@@ -82,7 +82,7 @@ def setup():
             ['git', 'reset', '--hard', 'FETCH_HEAD'], cwd=SRCDIR, check=True
         )
         # remove cached Meson subprojects
-        subprocess.run(['git', 'clean', '-dxf'], cwd=SRCDIR, check=True)
+        subprocess.run(['git', 'clean', '-dxff'], cwd=SRCDIR, check=True)
     else:
         subprocess.run(['git', 'clone', REPO, SRCDIR], check=True)
 


### PR DESCRIPTION
`git clean` won't remove nested Git repositories without `-ff`, and those are exactly what we have with Meson `[wrap-git]` wraps.