### PR TITLE
autobuild: `podman unshare` when cleaning Meson subprojects

### DIFF
--- a/autobuild/run.py
+++ b/autobuild/run.py
@@ -82,7 +82,10 @@ def setup():
             ['git', 'reset', '--hard', 'FETCH_HEAD'], cwd=SRCDIR, check=True
         )
         # remove cached Meson subprojects
-        subprocess.run(['git', 'clean', '-dxff'], cwd=SRCDIR, check=True)
+        subprocess.run(
+            ['podman', 'unshare', 'git', 'clean', '-dxff'],
+            cwd=SRCDIR, check=True
+        )
     else:
         subprocess.run(['git', 'clone', REPO, SRCDIR], check=True)
 


### PR DESCRIPTION
Avoid subuid permission problems when cleaning subprojects unpacked from tarballs that contain non-zero UIDs.