### PR TITLE
autobuild: disable `werror` for libdicom

### DIFF
--- a/autobuild/test.sh
+++ b/autobuild/test.sh
@@ -27,7 +27,9 @@ OUT="/out"
 # build
 cd "$SRC"
 git rev-parse HEAD
-if ! meson setup "$BUILD" --werror; then
+# disable werror for libdicom 1.2.0
+# https://github.com/ImagingDataCommons/libdicom/pull/100
+if ! meson setup "$BUILD" --werror -Dlibdicom:werror=false; then
     cat "$BUILD/meson-logs/meson-log.txt"
     exit 1
 fi


### PR DESCRIPTION
GCC 15 in Fedora 42 introduces a new libdicom build warning.  Disable `werror` for libdicom until this is fixed.